### PR TITLE
Support changing pipeline stage via I2C for each channel

### DIFF
--- a/modules/audio_pipelines/reference/fixed_delay/audio_pipeline_t0.c
+++ b/modules/audio_pipelines/reference/fixed_delay/audio_pipeline_t0.c
@@ -97,7 +97,8 @@ static void stage_vnr_and_ic(frame_data_t *frame_data)
     ic_adapt(&ic_stage_state.state, vnr_pred_stage_state.vnr_pred_state.input_vnr_pred);
 
     /* Intentionally ignoring comms ch from here on out */
-    memcpy(frame_data->samples, ic_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));
+    memcpy(frame_data->samples[0], ic_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));
+    memcpy(frame_data->aec_reference_audio_samples[0], ic_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));   // Store the interference cancelled audio in the first reference channel
 #endif
 }
 
@@ -111,7 +112,8 @@ static void stage_ns(frame_data_t *frame_data)
                 &ns_stage_state.state,
                 ns_output,
                 frame_data->samples[0]);
-    memcpy(frame_data->samples, ns_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));
+    memcpy(frame_data->samples[0], ns_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));
+    memcpy(frame_data->aec_reference_audio_samples[1], ns_output, appconfAUDIO_PIPELINE_FRAME_ADVANCE * sizeof(int32_t));   // Store NS audio in the second reference channel
 #endif
 }
 

--- a/src/ffva/src/app_conf.h
+++ b/src/ffva/src/app_conf.h
@@ -14,10 +14,10 @@
 #define APP_VERSION_MAJOR   1
 #endif
 #ifndef APP_VERSION_MINOR
-#define APP_VERSION_MINOR   2
+#define APP_VERSION_MINOR   3
 #endif
 #ifndef APP_VERSION_PATCH
-#define APP_VERSION_PATCH   1
+#define APP_VERSION_PATCH   0
 #endif
 
 /* Intertile port settings */

--- a/src/ffva/src/configuration/configuration_servicer.h
+++ b/src/ffva/src/configuration/configuration_servicer.h
@@ -6,16 +6,27 @@
 #define NUM_RESOURCES_CONFIGURATION_SERVICER            (1) // Configuration servicer
 
 #define CONFIGURATION_SERVICER_RESID_VNR_VALUE          0x00
-#define CONFIGURATION_SERVICER_RESID_AMP_ENABLE         0x10
 
-#define NUM_CONFIGURATION_SERVICER_RESID_CMDS           2
+#define CONFIGURATION_SERVICER_RESID_CHANNEL_0_STAGE    0x30
+#define CONFIGURATION_SERVICER_RESID_CHANNEL_1_STAGE    0x40
+
+#define NUM_CONFIGURATION_SERVICER_RESID_CMDS           3
 
 static control_cmd_info_t configuration_servicer_resid_cmd_map[] =
 {
     { CONFIGURATION_SERVICER_RESID_VNR_VALUE, 1, sizeof(uint8_t), CMD_READ_ONLY },
-    { CONFIGURATION_SERVICER_RESID_AMP_ENABLE, 1, sizeof(uint8_t), CMD_READ_WRITE },
+    { CONFIGURATION_SERVICER_RESID_CHANNEL_0_STAGE, 1, sizeof(uint8_t), CMD_READ_WRITE },
+    { CONFIGURATION_SERVICER_RESID_CHANNEL_1_STAGE, 1, sizeof(uint8_t), CMD_READ_WRITE },
 };
 
+enum e_pipeline_processing_stages
+{
+    PIPELINE_STAGE_NONE = 0,
+    PIPELINE_STAGE_AEC = 1,
+    PIPELINE_STAGE_IC = 2,
+    PIPELINE_STAGE_NS = 3,
+    PIPELINE_STAGE_AGC = 4,
+};
 // typedef struct {
 //     uint8_t hdr;
 //     uint8_t resid;
@@ -39,3 +50,6 @@ control_ret_t configuration_servicer_read_cmd(control_resource_info_t *res_info,
 control_ret_t configuration_servicer_write_cmd(control_resource_info_t *res_info, control_cmd_t cmd, const uint8_t *payload, size_t payload_len);
 
 void configuration_push_vnr_value(int value);
+
+enum e_pipeline_processing_stages configuration_get_channel_0_stage();
+enum e_pipeline_processing_stages configuration_get_channel_1_stage();


### PR DESCRIPTION
Allows setting the pipeline stage via I2C for each channel. It also removes the amp control command since that is no longer connected the XMOS chip.

Typically we want the AEC+IC+NS+AGC for channel 0, as that is piped to the STT engine. It's unclear what the optimal stage is for channel 1. The AGC seems to make microWakeWord falsely accept far more often than expected.