### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
         with:
           submodules: recursive
 
@@ -53,7 +53,7 @@ jobs:
           docker run --rm -u $(id -u):$(id -g) -w /sln_voice -v ${{github.workspace}}:/sln_voice ${XCORE_BUILDER} bash -l tools/ci/build_host_apps.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3.2.1
         with:
           name: ${{ env.HOST_APPS_ARTIFACT_NAME }}
           path: ./dist_host
@@ -64,7 +64,7 @@ jobs:
     needs: build_host_apps
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
         with:
           submodules: recursive
 
@@ -73,7 +73,7 @@ jobs:
           docker pull ${XCORE_BUILDER}
 
       - name: Download host build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
         with:
           name: ${{ env.HOST_APPS_ARTIFACT_NAME }}
           path: ./dist_host
@@ -93,7 +93,7 @@ jobs:
           fi
 
       - name: Save example app firmware artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3.2.1
         with:
           name: ${{ env.EXAMPLES_ARTIFACT_NAME }}
           path: |
@@ -106,7 +106,7 @@ jobs:
     needs: build_host_apps
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
         with:
           submodules: recursive
 
@@ -115,7 +115,7 @@ jobs:
           docker pull ${XCORE_BUILDER}
 
       - name: Download host build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
         with:
           name: ${{ env.HOST_APPS_ARTIFACT_NAME }}
           path: ./dist_host
@@ -131,7 +131,7 @@ jobs:
     needs: build_host_apps
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
         with:
           submodules: recursive
 
@@ -140,7 +140,7 @@ jobs:
           docker pull ${XCORE_BUILDER}
 
       - name: Download host build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
         with:
           name: ${{ env.HOST_APPS_ARTIFACT_NAME }}
           path: ./dist_host
@@ -157,7 +157,7 @@ jobs:
   #   needs: build_host_apps
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v3
+  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
   #       with:
   #         submodules: recursive
 
@@ -166,7 +166,7 @@ jobs:
   #         docker pull ${XCORE_BUILDER}
 
   #     - name: Download host build artifacts
-  #       uses: actions/download-artifact@v3
+  #       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
   #       with:
   #         name: ${{ env.HOST_APPS_ARTIFACT_NAME }}
   #         path: ./dist_host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     if: needs.event_configuration.outputs.is_release == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
         with:
           fetch-depth: 1
           submodules: recursive
@@ -116,7 +116,7 @@ jobs:
           zip -r --symlinks $RELEASE_SOURCES_DIR/${{ needs.event_configuration.outputs.src_artifact_name }}.zip .
 
       - name: Upload sources
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3.2.1
         with:
           name: ${{ needs.event_configuration.outputs.src_artifact_name }}
           path: ${{ env.RELEASE_SOURCES_DIR }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,9 +33,9 @@ jobs:
       dockerfile: ${{ steps.filter.outputs.dockerfile }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
       - name: Paths filter
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # v2.11.1
         id: filter
         with:
           filters: |
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc  # v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175  # v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -79,7 +79,7 @@ jobs:
             # sha-XXXXXXX
             type=sha
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4.2.1
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

Pin all GitHub Action and reusable workflow references to their full commit SHAs
instead of mutable tags or branch names.

Closes #8


## Why?

Referencing actions by tag (e.g., `actions/checkout@v4`) is convenient but
carries a supply-chain risk: tags are mutable and can be force-pushed to point
at arbitrary commits. If an action's tag is compromised, every workflow that
references it by tag will silently run the attacker's code.

Pinning to a full 40-character commit SHA (e.g.,
`actions/checkout@11bd719...`) makes the reference immutable. Even if a tag is
tampered with, workflows pinned to a SHA will continue to use the exact code
that was reviewed and trusted.

A version comment is included next to each SHA for readability
(e.g., `actions/checkout@11bd719... # v4.2.2`).

## References

- [GitHub Blog: Four tips to keep your GitHub Actions workflows secure](https://github.blog/open-source/four-tips-to-keep-your-github-actions-workflows-secure/#use-specific-action-version-tags)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [GitHub Docs: Enforcing SHA pinning for actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#requiring-workflows-to-use-pinned-versions-of-actions)
